### PR TITLE
Expose acceleration data

### DIFF
--- a/Headitude/ConnectionCalibrationView.swift
+++ b/Headitude/ConnectionCalibrationView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import CoreMotion
 
 struct ConnectionView: View {
     var appState: AppState
@@ -6,6 +7,8 @@ struct ConnectionView: View {
     @State private var yawInDegrees = 0.0
     @State private var pitchInDegrees = 0.0
     @State private var rollInDegrees = 0.0
+    
+    @State private var acceleration: CMAcceleration = .init();
 
     @State private var connected = true
     var body: some View {
@@ -29,6 +32,18 @@ struct ConnectionView: View {
                 Text("Roll:").foregroundColor(.gray)
                 Text(String(format: "%.1f°", rollInDegrees)).foregroundColor(.gray).frame(width: 50)
             }
+            HStack {
+                Text("Acc X:").foregroundColor(.gray)
+                Text(String(format: "%.2f G", acceleration.x)).foregroundColor(.gray).frame(width: 50)
+            }
+            HStack {
+                Text("Acc Y:").foregroundColor(.gray)
+                Text(String(format: "%.2f G", acceleration.y)).foregroundColor(.gray).frame(width: 50)
+            }
+            HStack {
+                Text("Acc Z:").foregroundColor(.gray)
+                Text(String(format: "%.2f G", acceleration.z)).foregroundColor(.gray).frame(width: 50)
+            }
         }
         .onReceive(appState.headphoneMotionDetector.$connected) {
             newState in connected = newState
@@ -42,6 +57,11 @@ struct ConnectionView: View {
             yawInDegrees = rad2deg(taitBryan.yaw)
             pitchInDegrees = rad2deg(taitBryan.pitch)
             rollInDegrees = rad2deg(taitBryan.roll)
+        }
+        .onReceive(
+            appState.$acceleration.throttle(for: 0.10, scheduler: RunLoop.main, latest: true)
+        ) { newAcceleration in
+            acceleration = newAcceleration
         }
     }
 }

--- a/Headitude/HeaditudeApp.swift
+++ b/Headitude/HeaditudeApp.swift
@@ -12,6 +12,7 @@ import SwiftUI
 class AppState: ObservableObject {
     /** Corrected quaternion using calibration. */
     @Published var quaternion = CMQuaternion()
+    @Published var acceleration = CMAcceleration()
 
     @AppStorage("AppState.calibration") private var calibration: Data = .init()
 
@@ -25,6 +26,9 @@ class AppState: ObservableObject {
         headphoneMotionDetector.onUpdate = { [self] in
             quaternion = self.headphoneMotionDetector.correctedQuaternion
             oscSender.setQuaternion(q: quaternion)
+            
+            acceleration = self.headphoneMotionDetector.userAcceleration;
+            oscSender.setAcceleration(a: acceleration)
         }
 
         headphoneMotionDetector.start()

--- a/Headitude/HeadphoneMotionDetector.swift
+++ b/Headitude/HeadphoneMotionDetector.swift
@@ -13,6 +13,7 @@ import SwiftUI
 class HeadphoneMotionDetector: NSObject, ObservableObject, CMHeadphoneMotionManagerDelegate {
     @Published var data: CMDeviceMotion = .init()
     @Published var correctedQuaternion: CMQuaternion = .init()
+    @Published var userAcceleration: CMAcceleration = .init()
     @Published var connected: Bool = false
 
     private let headphoneMotionManager = CMHeadphoneMotionManager()
@@ -47,6 +48,7 @@ class HeadphoneMotionDetector: NSObject, ObservableObject, CMHeadphoneMotionMana
                     if let motionData = motionData {
                         self.data = motionData
                         self.calibration.update(data: motionData)
+                        self.userAcceleration = motionData.userAcceleration;
                         self.correctedQuaternion = self.calibration.apply(to: motionData.attitude.quaternion)
                         self.onUpdate()
                     }

--- a/Headitude/OSCSender.swift
+++ b/Headitude/OSCSender.swift
@@ -19,6 +19,7 @@ class OSCSender: ObservableObject {
     private var client = OSCClient()
 
     private var quaternion: CMQuaternion = .init()
+    private var acceleration: CMAcceleration = .init();
 
     @AppStorage("oscSettings") var oscSettingsStore: Data = .init()
 
@@ -42,6 +43,10 @@ class OSCSender: ObservableObject {
         let oscSettingsData = OSCStorageType(ip: ip, port: port, oscProtocol: oscProtocol)
         guard let data = try? JSONEncoder().encode(oscSettingsData) else { return }
         oscSettingsStore = data
+    }
+    
+    func setAcceleration(a: CMAcceleration) {
+        acceleration = a;
     }
 
     func setQuaternion(q: CMQuaternion) {
@@ -108,6 +113,13 @@ class OSCSender: ObservableObject {
                 value = quaternion.y
             case "qz":
                 value = quaternion.z
+            
+            case "accx":
+                value = acceleration.x
+            case "accy":
+                value = acceleration.y
+            case "accz":
+                value = acceleration.z
 
             default:
                 if protocolValid { protocolValid = false }

--- a/README.md
+++ b/README.md
@@ -63,5 +63,11 @@ Currently the following tokens are supported:
 - `qx` Quaternion x
 - `qy` Quaternion y
 - `qz` Quaternion z
+-
+- `accX` Acceleration in x axis in G
+- `accY` Acceleration in y axis in G
+- `accZ` Acceleration in z axis in G
+
+A G is a unit of gravitation force equal to that exerted by the earth’s gravitational field (9.81 m s−2).
 
 **Note**: You can prepend a token with a `-` to flip the sign, e.g. `-yaw` or `-yawRad`.


### PR DESCRIPTION
Hey, thanks for this neat project.

We would like to use it for a project but also need to access the accelerometer data of the AirPods. Instead of writing yet another app I thought maybe it is possible to extend it via a PR?

I'd prefer to expose the acceleration as SI unit m/s, but I think it is probably better to stick closer to apples implementation here - there is for sure a reason why the use G instead of m/s

It is also my first time working with Swift, so please tell me if something can be done better.
The accelerometer data is also displayed in the GUI now

<img width="544" height="591" alt="image" src="https://github.com/user-attachments/assets/03dbf22a-f9f9-43b4-b461-9173b746cebf" />
